### PR TITLE
fix: fixed error in judgement when offset is zero

### DIFF
--- a/photo-compose/src/main/java/soup/compose/photo/PhotoState.kt
+++ b/photo-compose/src/main/java/soup/compose/photo/PhotoState.kt
@@ -132,7 +132,9 @@ public class PhotoState(
     }
 
     public val isScaled: Boolean
-        get() = currentScale != 1f || currentOffset != Offset.Zero
+        get() = currentScale != 1f || currentOffset.isZero.not()
+
+    private val Offset.isZero: Boolean get() = x == 0F && y == 0F
 
     /**
      * Animate to the initial state.


### PR DESCRIPTION
When I use it in conjunction HorizontalPager, I've found that sometimes swiping left or right doesn't work.

After some troubleshooting, I found that the problem occurs when the Offset is judged to be zero.

The `currentOffset` maybe get `-0.0F` value, even though `-0.0F == 0.0F`, but `Offset(-0F, 0.F) != Offset(0F, 0F)`.

This is a problem caused by the algorithm of the `packFloats` function.

So we can only determine if Offset is 0 by looking at the x and y values.
